### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Assume that it's a small muted music player without any audio.
 - Each song has a duration. After the song has played for that duration, it switches to next song which is evident from the animated change that occurs when next button is pressed. You will notice this if you stay on the first song for 30s.
 - The widget can be shut down from notification menu.
 
-##Demo
+## Demo
 https://www.youtube.com/watch?v=hdxdTkdNkVs
 
 ## License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
